### PR TITLE
Allowkillduringwarmup

### DIFF
--- a/code/game/g_cmds.c
+++ b/code/game/g_cmds.c
@@ -1102,7 +1102,7 @@ void Cmd_Kill_f( gentity_t *ent ) {
 		return;
 	}
   
-	if ( !g_allowKill.integer ) {
+  if ( !g_allowKill.integer  || ((g_allowKill.integer == -1) && ( level.warmupTime != 0 ))) {
 		trap_SendServerCommand( ent-g_entities,
                                 "print \"Selfkill not allowed on this server\n\"" );
 		return;

--- a/code/game/g_cmds.c
+++ b/code/game/g_cmds.c
@@ -1102,7 +1102,7 @@ void Cmd_Kill_f( gentity_t *ent ) {
 		return;
 	}
   
-  if ( !g_allowKill.integer  || ((g_allowKill.integer == -1) && ( level.warmupTime != 0 ))) {
+  if ( !g_allowKill.integer  || ((g_allowKill.integer == -1) && ( level.warmupTime == 0 ))) {
 		trap_SendServerCommand( ent-g_entities,
                                 "print \"Selfkill not allowed on this server\n\"" );
 		return;


### PR DESCRIPTION
by setting g_allowkill to -1 killing is allowed during warmup but not during the match as requested in https://github.com/Irbyz/aftershock-xe/issues/42