### PR TITLE
Showing what gametype means should not depend on missionpack enabled #40

### DIFF
--- a/code/cgame/cg_info.c
+++ b/code/cgame/cg_info.c
@@ -255,7 +255,6 @@ void CG_DrawInformation( void ) {
         case GT_CTF:
                 s = "Capture The Flag";
                 break;
-#ifdef MISSIONPACK
         case GT_1FCTF:
                 s = "One Flag CTF";
                 break;
@@ -265,7 +264,6 @@ void CG_DrawInformation( void ) {
         case GT_HARVESTER:
                 s = "Harvester";
                 break;
-#endif
         case GT_ELIMINATION:
                 s = "Elimination";
                 break;


### PR DESCRIPTION
https://github.com/Irbyz/aftershock-xe/issues/40