### PR TITLE
Added CVar g_legacyWeaponAmmo default "1"

### DIFF
--- a/code/game/g_items.c
+++ b/code/game/g_items.c
@@ -273,6 +273,18 @@ int Pickup_Weapon (gentity_t *ent, gentity_t *other) {
 			quantity = ent->item->quantity;
 		}
 
+    // dropped items and teamplay weapons always have full ammo
+    if ( ! (ent->flags & FL_DROPPED_ITEM) && g_gametype.integer != GT_TEAM ) {
+      if ( g_legacyWeaponAmmo.integer == 1 ) { 
+        // respawning rules
+        // drop the quantity if the already have over the minimum
+        if ( other->client->ps.ammo[ ent->item->giTag ] < quantity ) {
+          quantity = quantity - other->client->ps.ammo[ ent->item->giTag ];
+        } else {
+          quantity = 1;		// only add a single shot
+        }
+      }
+    }
 	}
 	
 	//G_Printf("%i \n", quantity );

--- a/code/game/g_local.h
+++ b/code/game/g_local.h
@@ -1406,6 +1406,8 @@ extern vmCvar_t     g_telefragTeamBehavior;
 extern vmCvar_t     g_furthestTeamSpawns;
 extern vmCvar_t	    g_ruleset;
 
+
+extern vmCvar_t	    g_legacyWeaponAmmo;
 // Weapon CVARs
 
 // Gauntlet

--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -245,6 +245,7 @@ vmCvar_t     g_allowMultiview;
 vmCvar_t     g_disableSpecs;
 
 vmCvar_t     g_friendsThroughWalls;
+vmCvar_t     g_legacyWeaponAmmo;
 vmCvar_t     g_allowKill;
 vmCvar_t     g_fadeToBlack;
 
@@ -595,6 +596,7 @@ static cvarTable_t		gameCvarTable[] = {
 	{ &g_disableSpecs, "g_disableSpecs", "0", CVAR_ARCHIVE, 0, qfalse },
 	{ &g_friendsThroughWalls, "g_friendsThroughWalls", "0", CVAR_SERVERINFO, 0, qfalse },
 	
+	{ &g_legacyWeaponAmmo, "g_legacyWeaponAmmo", "1", CVAR_ARCHIVE | CVAR_SERVERINFO, 0, qfalse },
 	{ &g_allowKill, "g_allowKill", "1", CVAR_SERVERINFO, 0, qfalse },
 	{ &g_fadeToBlack, "g_fadeToBlack", "0", CVAR_SERVERINFO, 0, qfalse },
 	{ &g_spawnProtection, "g_spawnProtection", "0", CVAR_ARCHIVE, 0, qfalse },


### PR DESCRIPTION
When g_legacyWeaponAmmo is set to 0 weapons you pick up will always add
the normal ammount of ammo you find when they spawn. When set to "1" it
will fill up the ammo of the player to normal ammount, or add 1 bullit
if already reached the normal ammount.