### PR TITLE
#16 recognise map 6++ as valid mapname

### DIFF
--- a/code/game/g_mapcycle.c
+++ b/code/game/g_mapcycle.c
@@ -88,7 +88,7 @@ static int G_setTokenType ( char* value ) {
 			rpar = qtrue;
 		else if ( value[count] >= '0' && value[count] <= '9' )
 			number = qtrue;
-		else if ( ( value[count] >= 'a' && value[count] <= 'z' ) || ( value[count] >= 'A' && value[count] <= 'Z' ) )
+		else if ( ( value[count] >= 'a' && value[count] <= 'z' ) || ( value[count] >= 'A' && value[count] <= 'Z' ) || (value[count] == '+' ) )
 			character = qtrue;
 		count++;
 	}


### PR DESCRIPTION
problem was not in the + but in the fact not one alphabet letter is in the name.
a-z A-Z only a number. So it didnt register as a string because of that

I added + to the alphabet letters in this patch and verified the mapcycle now supports 6++