### PR TITLE
Revert "avoid bug with firsttime variable and clear persistant on every connect"

### DIFF
--- a/code/game/g_client.c
+++ b/code/game/g_client.c
@@ -1836,11 +1836,11 @@ char *ClientConnect( int clientNum, qboolean firstTime, qboolean isBot ) {
 	
         client->pers.adminLevel = G_admin_level( ent );
 	client->pers.connected = CON_CONNECTING;
-  memset(&client->ps.persistant,0,sizeof(client->ps.persistant));
 
 	// read or initialize the session data
 	if ( firstTime || level.newSession ) {
 		G_InitSessionData( client, userinfo );
+    memset(&client->ps.persistant,0,sizeof(client->ps.persistant));
 	}
 	G_ReadSessionData( client );
 


### PR DESCRIPTION
Reverts Irbyz/aftershock-xe#84

The mistake was in my testing, not in the firsttime variable.