### PR TITLE
cg_fovbase, cg_zoomSensitivityASmode #123 cg_fovbasevertical

### DIFF
--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -1763,8 +1763,12 @@ extern vmCvar_t			cg_plasmaTrail;
 
 extern vmCvar_t 		cg_oldScoreboard;
 
+extern vmCvar_t   	cg_fovbase;
+extern vmCvar_t 	  cg_fovbasevertical;
+
 extern vmCvar_t			cg_chatBeep;
 extern vmCvar_t			cg_teamChatBeep;
+extern vmCvar_t    	cg_zoomSensitivityASmode;
 extern vmCvar_t			cg_zoomScaling;
 extern vmCvar_t 		cg_zoomToggle;
 extern vmCvar_t			cg_selfOnTeamOverlay;

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -390,6 +390,9 @@ vmCvar_t 	cg_oldScoreboard;
 vmCvar_t 	cg_chatBeep;
 vmCvar_t 	cg_teamChatBeep;
 
+vmCvar_t 	cg_fovbase;
+vmCvar_t 	cg_fovbasevertical;
+vmCvar_t 	cg_zoomSensitivityASmode;
 vmCvar_t 	cg_zoomScaling;
 vmCvar_t 	cg_zoomToggle;
 vmCvar_t 	cg_selfOnTeamOverlay;
@@ -686,6 +689,9 @@ static cvarTable_t cvarTable[] = { // bk001129
 	{&cg_oldScoreboard, "cg_oldScoreboard", "0", CVAR_ARCHIVE },
 	{&cg_chatBeep, "cg_chatBeep", "1", CVAR_ARCHIVE },
 	{&cg_teamChatBeep, "cg_teamChatBeep", "1", CVAR_ARCHIVE },
+	{&cg_fovbase, "cg_fovbase", "115", CVAR_ARCHIVE },
+	{&cg_fovbasevertical, "cg_fovbasevertical", "75", CVAR_ARCHIVE },
+	{&cg_zoomSensitivityASmode, "cg_zoomSensitivityASmode", "0", CVAR_ARCHIVE },
 	{&cg_zoomScaling, "cg_zoomScaling", "1", CVAR_ARCHIVE },
 	{&cg_zoomToggle, "cg_zoomToggle", "0", CVAR_ARCHIVE },
 	{&cg_selfOnTeamOverlay, "cg_selfOnTeamOverlay", "1", CVAR_ARCHIVE },

--- a/code/cgame/cg_view.c
+++ b/code/cgame/cg_view.c
@@ -504,11 +504,12 @@ static int CG_CalcFov( void ) {
     int		contents;
     float	fov_x, fov_y;
     float	zoomFov;
-    float	f;
+    float	f,scale;
     int		inwater;
 	int     zoomed;
 	int     zoomed_tmp;
 
+    f = 2.1;
     if ( cg.predictedPlayerState.pm_type == PM_INTERMISSION ) {
         // if in intermission, use a fixed value
         fov_x = 90;
@@ -614,8 +615,35 @@ static int CG_CalcFov( void ) {
 
     if ( !zoomed ) {
         cg.zoomSensitivity = 1;
+        if (cg_zoomSensitivityASmode.integer == 2) {
+                if (f <= 3.0) {
+                    scale = tan(cg.refdef.fov_x * M_PI/360.0) /tan(cg_fovbase.value * M_PI/360.0)  ;
+                    trap_Cvar_Set("m_pitch",va("%f",scale * 0.022));
+                    trap_Cvar_Set("m_yaw",va("%f",scale * 0.022));
+                }
+        }
     } else {
-        cg.zoomSensitivity = cg.refdef.fov_y / 75.0;
+        switch (cg_zoomSensitivityASmode.integer) {
+            default:
+            case 0:
+                cg.zoomSensitivity = cg.refdef.fov_y / cg_fovbasevertical.value;
+                break;
+            case 1:
+                cg.zoomSensitivity = tan(cg.refdef.fov_x * M_PI/360.0) /tan(cg_fovbase.value * M_PI/360.0)  ;
+                break;
+            case 2:
+                //cg.zoomSensitivity = cg.refdef.fov_y / cg_fovbasevertical.value;
+                cg.zoomSensitivity = 1;
+                if (f <= 3.0) {
+                    scale = tan(cg.refdef.fov_x * M_PI/360.0) /tan(cg_fovbase.value * M_PI/360.0)  ;
+                    trap_Cvar_Set("m_pitch",va("%f",scale * 0.022));
+                    trap_Cvar_Set("m_yaw",va("%f",scale * 0.022));
+                }
+                break;
+            case 3:
+                cg.zoomSensitivity = cg.refdef.fov_x  /cg_fovbase.value ;
+                break;
+        }
     }
 
     return inwater;


### PR DESCRIPTION
cg_fovbase (default 115) : the value cg_fov that is assumed to be your most common that you have adjusted your mouse sensitivity to.
cg_fovbasevertical (default 75): the vertical field of view of you most common cg_fov. see the openarena wikia for details.

cg_zoomSensitivityASmode
value 0: 
looks at cg_fovbasevertical (default 75) to calculate the sensitivity from the fov
value 1: 
looks at cg_fovbase (default 115) to calculate the sensitivity dynamically during zooming and zoom transitions. following the formula from the ODS spreadsheet
value 2:
looks at cg_fovbase but instead of the zoomsensitivity scaling it changes the m_pitch and m_yaw cvars.
follows ODS spreadsheet formula
value 3: (daviddmodus)
looks at cg_fovbase and does the quickest possible calculation